### PR TITLE
Added **/*tmp.* to .gitignore. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # This repo
 # Files
 config.json
+**/*tmp.*
 # Folders
 input
 output


### PR DESCRIPTION
This prevents files of any format that name suffixes with tmp from being tracked. It is poor naming convention and common for testing files that are not meant to be tracked in the first place.